### PR TITLE
Fix restore_old to handle missing modes

### DIFF
--- a/mpv-kscreen-doctor.lua
+++ b/mpv-kscreen-doctor.lua
@@ -172,7 +172,11 @@ local function restore_old()
 	--[[
 		If we know the previous modes, restore them
 	]]--
-	local modesfile = assert(io.open(MODESFILE, "r"), "Missing modes backup")
+       local modesfile = io.open(MODESFILE, "r")
+       if not modesfile then
+               -- nothing was ever saved
+               return
+       end
 
 	local old_modes = {}
 	while true do


### PR DESCRIPTION
## Summary
- avoid an assertion error when shutting down mpv without a backup file

## Testing
- `git commit -m "Fix restore_old to handle missing modes"`

------
https://chatgpt.com/codex/tasks/task_e_68774eb11c0883308c0e26bcca6c9ec4