### PR TITLE
Fix small typo

### DIFF
--- a/mpv-kscreen-doctor.lua
+++ b/mpv-kscreen-doctor.lua
@@ -89,7 +89,7 @@ local function get_available()
 		table.insert(valid_modes, { output = output, modes = good_modes })
 	end
 
-	-- save the modes if noone already did
+       -- save the modes if no one already did
 	local modesfile = io.open(MODESFILE, "r")
 	if not modesfile then
 		-- there is nothing saved yet


### PR DESCRIPTION
## Summary
- fix the typo "noone" -> "no one" in mpv-kscreen-doctor.lua comment

## Testing
- `luac -p mpv-kscreen-doctor.lua`

------
https://chatgpt.com/codex/tasks/task_e_687756c0945c8330a68fa348e5420d2d