### PR TITLE
Add LuaUnit test for best_fit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# mpv-kscreen-doctor
+
+This repository contains a simple mpv script to adjust display refresh rate using `kscreen-doctor`.
+
+## Running Tests
+
+The project uses [LuaUnit](https://luaunit.readthedocs.io/) for tests. To run the tests execute:
+
+```sh
+lua tests/test_best_fit.lua
+```
+

--- a/tests/test_best_fit.lua
+++ b/tests/test_best_fit.lua
@@ -1,0 +1,31 @@
+local luaunit = require('luaunit')
+
+local function best_fit(target, options)
+    local best = { distance = math.huge, id = nil }
+    for mul = 1, 3 do
+        for _, mode in pairs(options) do
+            local offset = math.abs(target * mul - mode.rate)
+            if offset < best.distance then
+                best = {
+                    distance = offset,
+                    id = mode.id,
+                }
+            end
+        end
+    end
+    return best.id
+end
+
+TestBestFit = {}
+
+function TestBestFit:test_simple_case()
+    local modes = {
+        {id = 1, rate = 59.94},
+        {id = 2, rate = 60.0},
+        {id = 3, rate = 120.0},
+    }
+    luaunit.assertEquals(best_fit(24.0, modes), 1)
+end
+
+os.exit(luaunit.LuaUnit.run())
+


### PR DESCRIPTION
## Summary
- add basic LuaUnit test for `best_fit`
- document running the tests in the new README

## Testing
- `lua tests/test_best_fit.lua`


------
https://chatgpt.com/codex/tasks/task_e_687757e398248330b127564c7a645273